### PR TITLE
Update stretch version to latest 9.9.0

### DIFF
--- a/debian-stretch
+++ b/debian-stretch
@@ -1,6 +1,6 @@
 {
   "variables": {
-      "debian_version": "9.4.0"
+      "debian_version": "9.9.0"
   },
   "builders": [
     {


### PR DESCRIPTION
I went to use this earlier and noticed it wasn't on the latest version. I figured I'd toss an update out since 9.10 doesn't seem to currently be planned. 👍